### PR TITLE
Automation: Add phylogenetic automation (with --keep-going)

### DIFF
--- a/.github/workflows/phylogenetic.yaml
+++ b/.github/workflows/phylogenetic.yaml
@@ -28,8 +28,8 @@ on:
       trial_name:
         description: |
           Trial name for deploying builds.
-          If not set, builds will overwrite existing builds at s3://nextstrain-data/zika*
-          If set, builds will be deployed to s3://nextstrain-staging/zika_trials_<trial_name>_*
+          If not set, builds will overwrite existing builds at s3://nextstrain-data/norovirus*
+          If set, builds will be deployed to s3://nextstrain-staging/norovirus_trials_<trial_name>_*
         required: false
         type: string
       sequences_url:
@@ -60,8 +60,8 @@ jobs:
           AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
         run: |
           s3_urls=(
-            "s3://nextstrain-data/files/workflows/zika/metadata.tsv.zst"
-            "s3://nextstrain-data/files/workflows/zika/sequences.fasta.zst"
+            "s3://nextstrain-data/files/workflows/norovirus/metadata.tsv.zst"
+            "s3://nextstrain-data/files/workflows/norovirus/sequences.fasta.zst"
           )
 
           # Code below is modified from ingest/upload-to-s3
@@ -115,7 +115,7 @@ jobs:
         declare -a config
 
         if [[ "$TRIAL_NAME" ]]; then
-          config+=("deploy_url=s3://nextstrain-staging/zika_trials_${TRIAL_NAME}_")
+          config+=("deploy_url=s3://nextstrain-staging/norovirus_trials_${TRIAL_NAME}_")
         fi
 
         if [[ "$SEQUENCES_URL" ]]; then
@@ -130,6 +130,7 @@ jobs:
           phylogenetic \
             deploy_all \
             --configfile build-configs/nextstrain-automation/config.yaml \
+            --keep-going \
             --config "${config[@]}"
       # Specifying artifact name to differentiate ingest build outputs from
       # the phylogenetic build outputs

--- a/.github/workflows/phylogenetic.yaml
+++ b/.github/workflows/phylogenetic.yaml
@@ -1,0 +1,142 @@
+name: Phylogenetic
+
+defaults:
+  run:
+    # This is the same as GitHub Action's `bash` keyword as of 20 June 2023:
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+    #
+    # Completely spelling it out here so that GitHub can't change it out from under us
+    # and we don't have to refer to the docs to know the expected behavior.
+    shell: bash --noprofile --norc -eo pipefail {0}
+
+on:
+  # This workflow will be triggered after the "Ingest" workflow has completed on the "main" branch.
+  workflow_run:
+    workflows:
+      - Ingest
+    types:
+      - completed
+    branches:
+      - main
+
+  workflow_dispatch:
+    inputs:
+      image:
+        description: 'Specific container image to use for ingest workflow (will override the default of "nextstrain build")'
+        required: false
+        type: string
+      trial_name:
+        description: |
+          Trial name for deploying builds.
+          If not set, builds will overwrite existing builds at s3://nextstrain-data/zika*
+          If set, builds will be deployed to s3://nextstrain-staging/zika_trials_<trial_name>_*
+        required: false
+        type: string
+      sequences_url:
+        description: |
+          URL for a sequences.fasta.zst file.
+          If not provided, will use default sequences_url from phylogenetic/defaults/config.yaml
+        required: false
+        type: string
+      metadata_url:
+        description: |
+          URL for a metadata.tsv.zst file.
+          If not provided, will use default metadata_url from phylogenetic/defaults/config.yaml
+        required: false
+        type: string
+
+jobs:
+  check-new-data:
+    if: |
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      cache-hit: ${{ steps.check-cache.outputs.cache-hit }}
+    steps:
+      - name: Get sha256sum
+        id: get-sha256sum
+        env:
+          AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
+        run: |
+          s3_urls=(
+            "s3://nextstrain-data/files/workflows/zika/metadata.tsv.zst"
+            "s3://nextstrain-data/files/workflows/zika/sequences.fasta.zst"
+          )
+
+          # Code below is modified from ingest/upload-to-s3
+          # https://github.com/nextstrain/ingest/blob/c0b4c6bb5e6ccbba86374d2c09b42077768aac23/upload-to-s3#L23-L29
+
+          no_hash=0000000000000000000000000000000000000000000000000000000000000000
+
+          for s3_url in "${s3_urls[@]}"; do
+            s3path="${s3_url#s3://}"
+            bucket="${s3path%%/*}"
+            key="${s3path#*/}"
+
+            s3_hash="$(aws s3api head-object --no-sign-request --bucket "$bucket" --key "$key" --query Metadata.sha256sum --output text 2>/dev/null || echo "$no_hash")"
+            echo "${s3_hash}" | tee -a ingest-output-sha256sum
+          done
+
+      - name: Check cache
+        id: check-cache
+        uses: actions/cache@v4
+        with:
+          path: ingest-output-sha256sum
+          key: ingest-output-sha256sum-${{ hashFiles('ingest-output-sha256sum') }}
+          lookup-only: true
+
+  phylogenetic:
+    # Run the workflow under two conditions
+    # 1. `workflow_run` triggered `check-new-data` and there's new data (no cache hit)
+    # 2. the workflow is being manually run by `workflow_dispatch`
+    needs: [check-new-data]
+    if: |
+      always() &&
+      (
+        (needs.check-new-data.result == 'success' && needs.check-new-data.outputs.cache-hit != 'true') ||
+        github.event_name == 'workflow_dispatch'
+      )
+    permissions:
+      id-token: write
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
+    secrets: inherit
+    with:
+      # Starting with the default docker runtime
+      # We can migrate to AWS Batch when/if we need to for more resources or if
+      # the job runs longer than the GH Action limit of 6 hours.
+      runtime: docker
+      env: |
+        NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
+        TRIAL_NAME: ${{ inputs.trial_name }}
+        SEQUENCES_URL: ${{ inputs.sequences_url }}
+        METADATA_URL: ${{ inputs.metadata_url }}
+      run: |
+        declare -a config
+
+        if [[ "$TRIAL_NAME" ]]; then
+          config+=("deploy_url=s3://nextstrain-staging/zika_trials_${TRIAL_NAME}_")
+        fi
+
+        if [[ "$SEQUENCES_URL" ]]; then
+          config+=("sequences_url=$SEQUENCES_URL")
+        fi
+
+        if [[ "$METADATA_URL" ]]; then
+          config+=("metadata_url=$METADATA_URL")
+        fi
+
+        nextstrain build \
+          phylogenetic \
+            deploy_all \
+            --configfile build-configs/nextstrain-automation/config.yaml \
+            --config "${config[@]}"
+      # Specifying artifact name to differentiate ingest build outputs from
+      # the phylogenetic build outputs
+      artifact-name: phylogenetic-build-output
+      artifact-paths: |
+        phylogenetic/auspice/
+        phylogenetic/results/
+        phylogenetic/benchmarks/
+        phylogenetic/logs/
+        phylogenetic/.snakemake/log/


### PR DESCRIPTION
## Description of proposed changes

Turns on phylogenetic automation, since we've reduced number of trees from 54 to 14. 

## Related issue(s)

* Originally implemented in https://github.com/nextstrain/norovirus/pull/17, but split out here since it can be independently reviewed
* Part of https://github.com/nextstrain/norovirus/issues/4
## Checklist

- [ ] Checks pass
- [ ] Update changelog

