### PR TITLE
Phylogenetic: Set clock rate to reduce intermittent errors from negative rate estimate

### DIFF
--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -36,15 +36,15 @@ refine:
   # Estimated from auspice build https://github.com/nextstrain/norovirus/issues/22#issuecomment-3221851561
   clock_rate:
     all:
-      genome: 0.00249
+      genome: 0.00328
       p48: 0.00409
       NTPase: 0.00174
       p22: 0.00174
-      VPg: 0.00463
-      3CLpro: 0.00225
+      VPg: 0.00660
+      3CLpro: 0.00331
       RdRp: 0.00135
       VP1: 0.00136
-      VP2: 0.00169
+      VP2: 0.00228
     GII.2:
       genome: 0.000211
     GII.3:

--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -33,6 +33,28 @@ refine:
       genome: best --timetree --date-confidence
     GII.4:
       genome: mid_point --timetree --date-confidence
+  # Estimated from auspice build https://github.com/nextstrain/norovirus/issues/22#issuecomment-3221851561
+  clock_rate:
+    all:
+      genome: 0.00249
+      p48: 0.00409
+      NTPase: 0.00174
+      p22: 0.00174
+      VPg: 0.00463
+      3CLpro: 0.00225
+      RdRp: 0.00135
+      VP1: 0.00136
+      VP2: 0.00169
+    GII.2:
+      genome: 0.000211
+    GII.3:
+      genome: 0.000688
+    GII.4:
+      genome: 0.000874
+    GII.6:
+      genome: 0.000135
+    GII.17:
+      genome: 0.00142
 
 traits:
   default: region country ORF1_type ORF2_type host


### PR DESCRIPTION
## Description of proposed changes

Set clock rate for the builds otherwise the phylogenetic workflow gets intermittent errors from a negative rate estimate. Clock rate estimates are based on:


| group  | genome      | p48        | NTPase | p22    | VPg    | 3CLpro                                                                                                            | RdRp  | VP1  | VP2 |
| :--| :-- | :--  | :--| :-- | :--| :-- | :--| :--| :-- |
| all    | [genome](https://nextstrain.org/staging/norovirus/trials/testclockrate/norovirus/all/genome?l=clock) 0.00328    | [p48](https://nextstrain.org/staging/norovirus/trials/clockestimate/norovirus/all/p48?l=clock) 0.00409 | [NTPase](https://nextstrain.org/staging/norovirus/trials/clockestimate/norovirus/all/NTPase?l=clock) 0.00174 | [p22](https://nextstrain.org/staging/norovirus/trials/clockestimate/norovirus/all/p22?l=clock) 0.00174 | [VPg](https://nextstrain.org/staging/norovirus/trials/testclockrate/norovirus/all/VPg?l=clock) 0.00660 | [3CLpro](https://next.nextstrain.org/staging/norovirus/trials/testclockrate/norovirus/all/3CLpro?l=clock) 0.00331 | [RdRp](https://nextstrain.org/staging/norovirus/trials/clockestimate/norovirus/all/RdRp?l=clock) 0.00135 | [VP1](https://nextstrain.org/staging/norovirus/trials/clockestimate/norovirus/all/VP1?l=clock) 0.00136 | [VP2](https://nextstrain.org/staging/norovirus/trials/testclockrate/norovirus/all/VP2?l=clock) 0.00228 |
| GII.2  | [genome](https://nextstrain.org/staging/norovirus/trials/clockestimate/norovirus/GII.2/genome?l=clock) 0.000211 |       |      |   |      |   |   |      |     |
| GII.3  | [genome](https://nextstrain.org/staging/norovirus/trials/clockestimate/norovirus/GII.3/genome?l=clock) 0.000688 |                                                                                                        |                                                                                                              |                                                                                                        |                                                                                                        |                                                                                                                   |                                                                                                          |                                                                                                        |                                                                                                        |
| GII.4  | [genome](https://nextstrain.org/staging/norovirus/trials/clockestimate/norovirus/GII.4/genome?l=clock) 0.000874 |                                                                                                        |                                                                                                              |                                                                                                        |                                                                                                        |                                                                                                                   |                                                                                                          |                                                                                                        |                                                                                                        |
| GII.6  | [genome](https://nextstrain.org/staging/norovirus/trials/clockestimate/norovirus/GII.6/genome?l=clock) 0.000135 |                                                                                                        |                                                                                                              |                                                                                                        |                                                                                                        |                                                                                                                   |                                                                                                          |                                                                                                        |                                                                                                        |
| GII.17 | [genome](https://nextstrain.org/staging/norovirus/trials/clockestimate/norovirus/GII.17/genome?l=clock) 0.00142 |                                                                                                        |                                                                                                              |                                                                                                        |                                                                                                        |                                                                                                                   |                                                                                                          |                                                                                                        |                                                                                                        |




**Note about ease of testing**
I'm including the changes from https://github.com/nextstrain/norovirus/pull/24 so I can kick off phylogenetic GH tests and stage results. But plan to drop https://github.com/nextstrain/norovirus/pull/25/commits/cf90f7d0009ac00aeeb4cd7002f9bcfbcb7f9f39  before merging. 

## Related issue(s)

* Attempting to address: https://github.com/nextstrain/norovirus/issues/22

## Checklist

- [ ] Checks pass
- [ ] Update changelog

