### PR TITLE
Publish to main site

### DIFF
--- a/phylogenetic/build-configs/nextstrain-automation/config.yaml
+++ b/phylogenetic/build-configs/nextstrain-automation/config.yaml
@@ -1,4 +1,4 @@
 custom_rules:
   - build-configs/nextstrain-automation/deploy.smk
 
-deploy_url: "s3://nextstrain-staging"
+deploy_url: "s3://nextstrain-data"

--- a/phylogenetic/defaults/description.md
+++ b/phylogenetic/defaults/description.md
@@ -4,12 +4,12 @@ We gratefully acknowledge the authors, originating and submitting laboratories o
 
 | group | genome | p48 | NTPase | p22 | VPg | 3CLpro | RdRp | VP1 | VP2 |
 |:--|:--|:--|:--|:--|:--|:--|:--|:--|:--|
-| all | [genome](https://nextstrain.org/staging/norovirus/all/genome) | [p48](https://nextstrain.org/staging/norovirus/all/p48) | [NTPase](https://nextstrain.org/staging/norovirus/all/NTPase) | [p22](https://nextstrain.org/staging/norovirus/all/p22) | [VPg](https://nextstrain.org/staging/norovirus/all/VPg) | [3CLpro](https://nextstrain.org/staging/norovirus/all/3CLpro) | [RdRp](https://nextstrain.org/staging/norovirus/all/RdRp/) | [VP1](https://nextstrain.org/staging/norovirus/all/VP1) | [VP2](https://nextstrain.org/staging/norovirus/all/VP2) |
-| GII.2 | [genome](https://nextstrain.org/staging/norovirus/GII.2/genome) | | | | | | | | |
-| GII.3 | [genome](https://nextstrain.org/staging/norovirus/GII.3/genome) | | | | | | | | |
-| GII.4 | [genome](https://nextstrain.org/staging/norovirus/GII.4/genome) | | | | | | | | |
-| GII.6 | [genome](https://nextstrain.org/staging/norovirus/GII.6/genome) | | | | | | | | |
-| GII.17 | [genome](https://nextstrain.org/staging/norovirus/GII.17/genome) | | | | | | | | |
+| all | [genome](https://nextstrain.org/norovirus/all/genome) | [p48](https://nextstrain.org/norovirus/all/p48) | [NTPase](https://nextstrain.org/norovirus/all/NTPase) | [p22](https://nextstrain.org/norovirus/all/p22) | [VPg](https://nextstrain.org/norovirus/all/VPg) | [3CLpro](https://nextstrain.org/norovirus/all/3CLpro) | [RdRp](https://nextstrain.org/norovirus/all/RdRp/) | [VP1](https://nextstrain.org/norovirus/all/VP1) | [VP2](https://nextstrain.org/norovirus/all/VP2) |
+| GII.2 | [genome](https://nextstrain.org/norovirus/GII.2/genome) | | | | | | | | |
+| GII.3 | [genome](https://nextstrain.org/norovirus/GII.3/genome) | | | | | | | | |
+| GII.4 | [genome](https://nextstrain.org/norovirus/GII.4/genome) | | | | | | | | |
+| GII.6 | [genome](https://nextstrain.org/norovirus/GII.6/genome) | | | | | | | | |
+| GII.17 | [genome](https://nextstrain.org/norovirus/GII.17/genome) | | | | | | | | |
 
 
 #### Underlying data


### PR DESCRIPTION
## Description of proposed changes

Switch from staging to main site. Standing up this PR in case people want the Norovirus builds public sooner rather than later. 

We can continue to tune and refine the nextclade datasets, host mapping, and entropy panel (VP2 annotation).

## Related issue(s)


## Checklist

- [ ] Checks pass
- [ ] Update changelog
- [ ] Post-merge: Add norovirus to [data/manifest_core.json](https://github.com/nextstrain/nextstrain.org/tree/add-norovirus)

