### PR TITLE
CI: Only check two builds instead of 14

### DIFF
--- a/phylogenetic/build-configs/ci/config.yaml
+++ b/phylogenetic/build-configs/ci/config.yaml
@@ -1,6 +1,11 @@
 # This configuration file contains the custom configurations parameters
 # for the CI workflow to run with the example data.
 
+# {group} represents different genotypes to be analyzed
+groups: ['all']
+# {gene} represents the norovirus genes to focus on in each build
+genes: ['genome', 'VP1']
+
 inputs:
   - name: ncbi
     metadata: "example_data/metadata.tsv"


### PR DESCRIPTION
## Description of proposed changes

In response to https://github.com/nextstrain/norovirus/pull/37#issuecomment-3438089249 , only check all/genome and all/VP1

## Related issue(s)

## Checklist

- [ ] Checks pass
- [ ] Update changelog

