### PR TITLE
.github/workflows/phylogenetic: Fix artifact paths

### DIFF
--- a/.github/workflows/phylogenetic.yaml
+++ b/.github/workflows/phylogenetic.yaml
@@ -192,11 +192,11 @@ jobs:
       # the phylogenetic build outputs
       artifact-name: phylogenetic_genes-build-output
       artifact-paths: |
-        phylogenetic_genes/auspice/
-        phylogenetic_genes/results/
-        phylogenetic_genes/benchmarks/
-        phylogenetic_genes/logs/
-        phylogenetic_genes/.snakemake/log/
+        phylogenetic/auspice/
+        phylogenetic/results/
+        phylogenetic/benchmarks/
+        phylogenetic/logs/
+        phylogenetic/.snakemake/log/
 
   summary:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description of proposed changes

I was curious why the `phylogenetic_genes` job ran so much longer than the  `phylogenetic` job and wanted to check the benchmarks. This made me realize that the `phylogenetic_genes-build-output` artifact did not include the benchmark  files as expected.

## Related issue(s)

Follow up to https://github.com/nextstrain/norovirus/pull/24

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Update changelog: Not updating since this is an internal change only

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
